### PR TITLE
Use ourself for the build

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,6 +4,9 @@ license = Perl_5
 copyright_holder = Leon Timmermans
 copyright_year   = 2011
 
+;Use this plugin to build ourself
+[Bootstrap::lib]
+
 ;Building
 [@LEONT]
 install_tool = mbt


### PR DESCRIPTION
Use the version of the plugin in lib/ instead of the (older) installed one.
