### PR TITLE
Topic/uninstallable scripts

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist-Zilla-Plugin-ModuleBuildTiny
 
 {{$NEXT}}
+          Prohibit the use of executables from a directory other than script/
 
 0.014     2015-08-22 19:23:20+02:00 Europe/Amsterdam
           Increase minimum MBT in conservative logic

--- a/lib/Dist/Zilla/Plugin/ModuleBuildTiny.pm
+++ b/lib/Dist/Zilla/Plugin/ModuleBuildTiny.pm
@@ -141,6 +141,12 @@ sub setup_installer {
 		$self->log_fatal('Sharedir location must be share/') if defined $map->{dist} and $map->{dist} ne 'share';
 	}
 
+	for my $file (map { $_->name } @{$self->zilla->find_files(':ExecFiles')})
+	{
+		$self->log_fatal("detected file '$file' that will not be installed as an executable - move it to script/\n")
+			if $file !~ /^script/;
+	}
+
 	my $file = first { $_->name eq 'Build.PL' } @{$self->zilla->files};
 	my $content = $file->content;
 

--- a/t/bad-script.t
+++ b/t/bad-script.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings FATAL => 'all';
+
+use Test::More;
+use Test::Fatal;
+use Test::DZil;
+
+my $tzil = Builder->from_config(
+	{ dist_root => 't/does_not_exist' },
+	{
+		add_files => {
+			'source/dist.ini' => simple_ini(
+				'GatherDir',
+				'ExecDir',  # defaults to bin/
+				'ModuleBuildTiny',
+			),
+			'source/bin/exe' => 'executable content',
+		},
+	},
+);
+
+like(
+	exception { $tzil->build },
+	qr{detected file 'bin/exe' that will not be installed as an executable - move it to script},
+	'warning issued when there is an ExecFile outside of script/',
+);
+
+done_testing;
+
+# vim: set ts=4 sw=4 noet nolist :


### PR DESCRIPTION
as discussed:

```
09:13 < ether> leont: would you be supportive of an addition to [ModuleBuildTiny] that warned if [ExecDir] picked up files from bin/ rather than script/ (which MBT will not install)?  currently I have a warning in my pluginbundle if -d bin/ but this check would be useful to others too
09:15 < ether> I figure it could simply call the -ExecFiles plugins (like the MakeMaker and MB plugins do) and log_warn if any are not in script/
00:50 < leont> ether_: Yes, that may be a good idea
```
