### PR TITLE
bump a prereqs to avoid meta validation issues

### DIFF
--- a/lib/Dist/Zilla/Plugin/ModuleBuildTiny.pm
+++ b/lib/Dist/Zilla/Plugin/ModuleBuildTiny.pm
@@ -8,6 +8,7 @@ with qw/
 	Dist::Zilla::Role::FileGatherer
 /;
 
+use Dist::Zilla 4.300039;
 use Module::Metadata;
 use Moose::Util::TypeConstraints 'enum';
 use MooseX::Types::Perl qw/StrictVersionStr/;


### PR DESCRIPTION
Earlier versions of Dist::Zilla produced license data that fails validation
starting with CPAN::Meta 2.132620

and gives errors like:

```
[MetaJSON] Invalid META structure.  Errors found:
[MetaJSON] Expected a list structure (license) [Validation: 2] at /Volumes/amaretto/Users/ether/.perlbrew/libs/20.0@std/lib/perl5/darwin-2level/Moose/Meta/Method/Delegation.pm line 110.
t/basic.t ............... 
Dubious, test returned 25 (wstat 6400, 0x1900)
No subtests run 
```